### PR TITLE
Use local Microsoft and GM logos with enhanced hover animation

### DIFF
--- a/gm.svg
+++ b/gm.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="5" y="5" width="90" height="90" rx="15" fill="#0A7BC1"/>
+  <text x="50" y="60" text-anchor="middle" font-family="Arial, sans-serif" font-size="48" fill="#ffffff">gm</text>
+  <rect x="30" y="72" width="40" height="8" fill="#ffffff"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -23,22 +23,22 @@
       <a href="#about">ABOUT
         <span class="nav-logos">
           <img src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/9/96/Microsoft_logo_%282012%29.svg" alt="Microsoft logo">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/4/4f/General_Motors_logo.svg" alt="General Motors logo">
+          <img src="microsoft.svg" alt="Microsoft logo">
+          <img src="gm.svg" alt="General Motors logo">
         </span>
       </a>
       <a href="#projects">PROJECTS
         <span class="nav-logos">
           <img src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/9/96/Microsoft_logo_%282012%29.svg" alt="Microsoft logo">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/4/4f/General_Motors_logo.svg" alt="General Motors logo">
+          <img src="microsoft.svg" alt="Microsoft logo">
+          <img src="gm.svg" alt="General Motors logo">
         </span>
       </a>
       <a href="#contact">CONTACT
         <span class="nav-logos">
           <img src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/9/96/Microsoft_logo_%282012%29.svg" alt="Microsoft logo">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/4/4f/General_Motors_logo.svg" alt="General Motors logo">
+          <img src="microsoft.svg" alt="Microsoft logo">
+          <img src="gm.svg" alt="General Motors logo">
         </span>
       </a>
     </nav>
@@ -66,14 +66,14 @@
           </div>
         </div>
         <div class="experience-card">
-          <img class="experience-logo" src="https://upload.wikimedia.org/wikipedia/commons/9/96/Microsoft_logo_%282012%29.svg" alt="Microsoft logo">
+          <img class="experience-logo" src="microsoft.svg" alt="Microsoft logo">
           <div>
             <h3>Microsoft</h3>
             <p>Placeholder role description at Microsoft.</p>
           </div>
         </div>
         <div class="experience-card">
-          <img class="experience-logo" src="https://upload.wikimedia.org/wikipedia/commons/4/4f/General_Motors_logo.svg" alt="General Motors logo">
+          <img class="experience-logo" src="gm.svg" alt="General Motors logo">
           <div>
             <h3>General Motors</h3>
             <p>Placeholder role description at General Motors.</p>

--- a/microsoft.svg
+++ b/microsoft.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="48" height="48" x="0" y="0" fill="#F25022"/>
+  <rect width="48" height="48" x="52" y="0" fill="#7FBA00"/>
+  <rect width="48" height="48" x="0" y="52" fill="#00A4EF"/>
+  <rect width="48" height="48" x="52" y="52" fill="#FFB900"/>
+</svg>

--- a/style.css
+++ b/style.css
@@ -155,7 +155,7 @@ font-size: clamp(3rem, 8vw, 8rem);
   position: absolute;
   left: 100%;
   top: 50%;
-  transform: translateY(-50%) translateX(-20px);
+  transform: translateY(-50%) translateX(-40px);
   opacity: 0;
   display: flex;
   gap: 0.5rem;
@@ -164,14 +164,15 @@ font-size: clamp(3rem, 8vw, 8rem);
 }
 
 .nav-logos img {
-  width: 40px;
-  height: 40px;
+  width: 50px;
+  height: 50px;
   object-fit: contain;
+  transition: transform 0.3s ease, filter 0.3s ease;
 }
 
 .menu a:hover .nav-logos {
   opacity: 1;
-  transform: translateY(-50%) translateX(10px);
+  transform: translateY(-50%) translateX(20px);
 }
 
 section {
@@ -246,6 +247,10 @@ font-size: clamp(5rem, 6vw, 7rem);
   width: 60px;
   height: 60px;
   object-fit: contain;
+  transition: transform 0.3s ease;
+}
+.experience-card:hover .experience-logo {
+  transform: scale(1.1);
 }
 
 .projects-grid {
@@ -292,4 +297,8 @@ font-size: clamp(3rem, 5vw, 4rem);
 }
 
 
+}
+.menu a:hover .nav-logos img {
+  transform: scale(1.2);
+  filter: drop-shadow(0 0 6px var(--accent-color));
 }


### PR DESCRIPTION
## Summary
- replace Microsoft and General Motors logos with local svg assets
- update navigation hover animation to pop out logos with scaling and drop shadow
- add hover scale effect for experience logos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3755b7c288329ab7e2885ee80d121