### PR TITLE
Fix nav hover logos overlapping

### DIFF
--- a/style.css
+++ b/style.css
@@ -139,7 +139,7 @@ font-size: clamp(3rem, 8vw, 8rem);
   position: absolute;
   top: 100%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, 10px);
   border-width: 6px;
   border-style: solid;
   border-color: #2c2c2c transparent transparent transparent;
@@ -152,50 +152,27 @@ font-size: clamp(3rem, 8vw, 8rem);
 
 .nav-logos {
   position: absolute;
-  top: 50%;
-
+  top: 100%;
   left: 50%;
-  transform: translate(-50%, -50%);
-  width: 0;
-  height: 0;
-
+  transform: translate(-50%, 10px);
+  display: flex;
+  gap: 1rem;
   pointer-events: none;
 }
 
 .nav-logos img {
-
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 50px;
   height: 50px;
   object-fit: contain;
   opacity: 0;
-  transform: translate(0, 0) scale(0);
+  transform: translateY(-10px) scale(0);
   transition: transform 0.3s ease, opacity 0.3s ease, filter 0.3s ease;
-
 }
 
 .menu a:hover .nav-logos img {
   opacity: 1;
-
+  transform: translateY(0) scale(1.2);
   filter: drop-shadow(0 0 6px var(--accent-color));
-}
-
-.menu a:hover .nav-logos img:nth-child(1) {
-.menu a:hover .nav-logos img:nth-child(1) {
-  transform: translate(-160px, 80px) scale(1.2);
-}
-.menu a:hover .nav-logos img:nth-child(2) {
-  transform: translate(-70px, 120px) scale(1.2);
-}
-.menu a:hover .nav-logos img:nth-child(3) {
-  transform: translate(70px, 120px) scale(1.2);
-}
-.menu a:hover .nav-logos img:nth-child(4) {
-  transform: translate(160px, 80px) scale(1.2);
-}
-
 }
 
 section {
@@ -318,8 +295,4 @@ font-size: clamp(3rem, 5vw, 4rem);
 }
 
 
-}
-.menu a:hover .nav-logos img {
-  transform: scale(1.2);
-  filter: drop-shadow(0 0 6px var(--accent-color));
 }


### PR DESCRIPTION
## Summary
- Position navigation logos below the menu link and display them in a row
- Simplify animation so logos spread out underneath the text instead of overlapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c37e4de2b48329b4ba60b11c1a05d9