### PR TITLE
Show company logos only on About

### DIFF
--- a/centerline.svg
+++ b/centerline.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 115">
+  <style>
+    .text { font: 700 64px 'Arial', sans-serif; fill: #0055a4; }
+    .line { stroke: #a67926; stroke-width: 8; }
+  </style>
+  <line x1="20" y1="57.5" x2="120" y2="57.5" class="line" />
+  <line x1="70" y1="15" x2="70" y2="100" class="line" />
+  <text x="130" y="80" class="text">centerline</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -25,34 +25,12 @@
           <img src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
           <img src="microsoft.svg" alt="Microsoft logo">
           <img src="gm.svg" alt="General Motors logo">
-
           <img src="mcmaster.svg" alt="McMaster University logo">
-
-
+          <img src="centerline.svg" alt="Centerline logo">
         </span>
       </a>
-      <a href="#projects">PROJECTS
-        <span class="nav-logos">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
-          <img src="microsoft.svg" alt="Microsoft logo">
-          <img src="gm.svg" alt="General Motors logo">
-
-
-          <img src="mcmaster.svg" alt="McMaster University logo">
-
-        </span>
-      </a>
-      <a href="#contact">CONTACT
-        <span class="nav-logos">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
-          <img src="microsoft.svg" alt="Microsoft logo">
-          <img src="gm.svg" alt="General Motors logo">
-
-
-          <img src="mcmaster.svg" alt="McMaster University logo">
-
-        </span>
-      </a>
+      <a href="#projects">PROJECTS</a>
+      <a href="#contact">CONTACT</a>
     </nav>
     <div class="hero-image-wrapper">
       <img src="profile.jpg" alt="Danilo Malovic" class="hero-image">

--- a/style.css
+++ b/style.css
@@ -72,10 +72,8 @@ a {
   display: flex;
   flex-direction: column;
   gap: 3rem;
-
-
   flex: 1;
-
+  align-items: flex-start;
 }
 
 .menu a {
@@ -161,6 +159,7 @@ font-size: clamp(3rem, 8vw, 8rem);
   transform: translate(-50%, 10px);
   display: flex;
   gap: 1rem;
+  justify-content: center;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- limit navigation hover logos to the About link only
- include Centerline logo and center the logo group beneath About
## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c381fee1048329a1ebd98cbbe5f58e