### PR TITLE
Enable experience tab switching

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,40 +43,44 @@
       <h2 class="section-title">ABOUT.</h2>
       <p class="about-description">I'm a software engineer passionate about building impactful solutions. Here's some of my experience.</p>
       <div class="experience-filters">
-        <button class="filter-btn">Leadership Experience</button>
-        <button class="filter-btn active">All Experience</button>
-        <button class="filter-btn">Work Experience</button>
+        <button class="filter-btn" data-target="leadership">Leadership Experience</button>
+        <button class="filter-btn active" data-target="all">All Experience</button>
+        <button class="filter-btn" data-target="work">Work Experience</button>
       </div>
-      <div class="experience-grid">
-        <div class="experience-card">
-          <img class="experience-logo" src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
-          <div>
-            <h3>Tesla</h3>
-            <p>Placeholder role description at Tesla.</p>
+      <div class="experience-content active" id="all">
+        <div class="experience-grid">
+          <div class="experience-card">
+            <img class="experience-logo" src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
+            <div>
+              <h3>Tesla</h3>
+              <p>Placeholder role description at Tesla.</p>
+            </div>
           </div>
-        </div>
-        <div class="experience-card">
-          <img class="experience-logo" src="microsoft.svg" alt="Microsoft logo">
-          <div>
-            <h3>Microsoft</h3>
-            <p>Placeholder role description at Microsoft.</p>
+          <div class="experience-card">
+            <img class="experience-logo" src="microsoft.svg" alt="Microsoft logo">
+            <div>
+              <h3>Microsoft</h3>
+              <p>Placeholder role description at Microsoft.</p>
+            </div>
           </div>
-        </div>
-        <div class="experience-card">
-          <img class="experience-logo" src="gm.svg" alt="General Motors logo">
-          <div>
-            <h3>General Motors</h3>
-            <p>Placeholder role description at General Motors.</p>
+          <div class="experience-card">
+            <img class="experience-logo" src="gm.svg" alt="General Motors logo">
+            <div>
+              <h3>General Motors</h3>
+              <p>Placeholder role description at General Motors.</p>
+            </div>
           </div>
-        </div>
-        <div class="experience-card">
-          <img class="experience-logo" src="mcmaster.svg" alt="McMaster University logo">
-          <div>
-            <h3>McMaster University</h3>
-            <p>Placeholder role description at McMaster University.</p>
+          <div class="experience-card">
+            <img class="experience-logo" src="mcmaster.svg" alt="McMaster University logo">
+            <div>
+              <h3>McMaster University</h3>
+              <p>Placeholder role description at McMaster University.</p>
+            </div>
           </div>
         </div>
       </div>
+      <div class="experience-content" id="leadership"></div>
+      <div class="experience-content" id="work"></div>
     </div>
   </section>
 
@@ -102,5 +106,6 @@
       <p>Feel free to reach out at <a href="mailto:danmalovic@gmail.com">danmalovic@gmail.com</a>.</p>
     </div>
   </section>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const buttons = document.querySelectorAll('.filter-btn');
+  const contents = document.querySelectorAll('.experience-content');
+
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const target = btn.dataset.target;
+
+      buttons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+
+      contents.forEach(section => {
+        if (section.id === target) {
+          section.classList.add('active');
+        } else {
+          section.classList.remove('active');
+        }
+      });
+    });
+  });
+});

--- a/style.css
+++ b/style.css
@@ -237,6 +237,14 @@ font-size: clamp(5rem, 6vw, 7rem);
   gap: 1.5rem;
 }
 
+.experience-content {
+  display: none;
+}
+
+.experience-content.active {
+  display: block;
+}
+
 .experience-card {
   background: #1f1f1f;
   padding: 1rem;


### PR DESCRIPTION
## Summary
- add JS to switch between All, Leadership, and Work experience tabs
- style and markup updates to support tabbed content sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c444a35ce083298aa6787e0ab90727