### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -284,10 +284,16 @@ font-size: clamp(5rem, 6vw, 7rem);
 }
 
 @media (max-width: 768px) {
+  .topbar {
+    position: fixed;
+    z-index: 1000;
+  }
+
   .hero-section {
     flex-direction: column;
     text-align: center;
     gap: 2rem;
+    padding-top: 80px;
   }
 
   .menu {
@@ -295,15 +301,21 @@ font-size: clamp(5rem, 6vw, 7rem);
   }
 
   .menu a {
-font-size: clamp(3rem, 5vw, 4rem);
+    font-size: clamp(3rem, 5vw, 4rem);
   }
 
   .menu a::before {
     display: none;
   }
-.section-title {
-  font-size: 4rem;
-}
 
+  .hero-image {
+    width: 70vw;
+    height: 70vw;
+    max-width: 300px;
+    max-height: 300px;
+  }
 
+  .section-title {
+    font-size: 4rem;
+  }
 }


### PR DESCRIPTION
## Summary
- Fix overlapping About navigation with top message by adding top spacing on small screens
- Keep greeting visible with fixed topbar and adjust hero image sizing for mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c44618b92083299f06bdbe17c70a84