### PR TITLE
Add leadership experiences to portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,22 @@
         </div>
       </div>
       <div class="experience-content" id="leadership">
-        <div class="experience-grid"></div>
+        <div class="experience-grid">
+          <div class="experience-card">
+            <img class="experience-logo" src="mcmaster.svg" alt="McMaster University logo">
+            <div>
+              <h3>Senior Capstone Design Lead</h3>
+              <p>Led design and integration of the Custom Power Inverter project for the senior capstone.</p>
+            </div>
+          </div>
+          <div class="experience-card">
+            <img class="experience-logo" src="mcmaster.svg" alt="McMaster University logo">
+            <div>
+              <h3>MAC Formula Electric</h3>
+              <p>Senior member of the electrical subteam for the MAC Formula Electric FSAE race car project.</p>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Add senior capstone design lead and MAC Formula Electric electrical subteam leadership entries
- Reference associated project names in leadership experiences

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c70c31fd348329b34d4e95e77833bb