### PR TITLE
Default About tab to All Experience and add pointer hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,8 @@
 
   <section id="home" class="hero-section">
     <nav class="menu">
-      <a href="#about">ABOUT
+      <a href="#about" class="about-link">ABOUT
+        <span class="about-pointer">Click to view more details</span>
         <span class="nav-logos">
           <img src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
           <img src="microsoft.svg" alt="Microsoft logo">
@@ -45,11 +46,11 @@
       <h2 class="section-title">ABOUT.</h2>
       <p class="about-description">I'm an Electrical &amp; Computer Engineering Co-Op student at McMaster University (GPA: 3.5/4.0) and a US &amp; Canadian citizen with experience at Microsoft, General Motors, and Tesla.</p>
       <div class="experience-filters">
-        <button class="filter-btn active" data-target="work">Work Experience</button>
-        <button class="filter-btn" data-target="all">All Experience</button>
+        <button class="filter-btn" data-target="work">Work Experience</button>
+        <button class="filter-btn active" data-target="all">All Experience</button>
         <button class="filter-btn" data-target="leadership">Leadership Experience</button>
       </div>
-      <div class="experience-content" id="all">
+      <div class="experience-content active" id="all">
         <div class="experience-grid">
           <div class="experience-card">
             <img class="experience-logo" src="microsoft.svg" alt="Microsoft logo">
@@ -95,7 +96,7 @@
           </div>
         </div>
       </div>
-      <div class="experience-content active" id="work">
+      <div class="experience-content" id="work">
         <div class="experience-grid">
           <div class="experience-card">
             <img class="experience-logo" src="microsoft.svg" alt="Microsoft logo">

--- a/style.css
+++ b/style.css
@@ -109,6 +109,33 @@ font-size: clamp(3rem, 8vw, 8rem);
   width: 60px;
 }
 
+.about-link {
+  position: relative;
+}
+
+.about-pointer {
+  position: absolute;
+  left: -220px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: #2c2c2c;
+  color: var(--text-color);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.about-pointer::after {
+  content: '';
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: transparent transparent transparent #2c2c2c;
+}
+
 .hero-image {
   width: 450px;
   height: 450px;


### PR DESCRIPTION
## Summary
- Default the About section to show All Experience by default.
- Add a pointer hint near the About menu item guiding users to click for more details.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c72cbbf1b483299c1d6ffec77913df