### PR TITLE
Refine About tooltip placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,7 @@
 
   <section id="home" class="hero-section">
     <nav class="menu">
-      <a href="#about" class="about-link">ABOUT
-        <span class="about-pointer">Click to view more details</span>
+      <a href="#about">ABOUT
         <span class="nav-logos">
           <img src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
           <img src="microsoft.svg" alt="Microsoft logo">
@@ -43,7 +42,10 @@
 
   <section id="about" class="full-section">
     <div class="container">
-      <h2 class="section-title">ABOUT.</h2>
+      <div class="about-title">
+        <h2 class="section-title">ABOUT.</h2>
+        <span class="experience-tooltip">Click on my experience for more details!</span>
+      </div>
       <p class="about-description">I'm an Electrical &amp; Computer Engineering Co-Op student at McMaster University (GPA: 3.5/4.0) and a US &amp; Canadian citizen with experience at Microsoft, General Motors, and Tesla.</p>
       <div class="experience-filters">
         <button class="filter-btn" data-target="work">Work Experience</button>

--- a/style.css
+++ b/style.css
@@ -109,15 +109,16 @@ font-size: clamp(3rem, 8vw, 8rem);
   width: 60px;
 }
 
-.about-link {
+.about-title {
   position: relative;
+  display: inline-block;
 }
 
-.about-pointer {
+.experience-tooltip {
   position: absolute;
-  left: -220px;
+  left: 100%;
   top: 50%;
-  transform: translateY(-50%);
+  transform: translate(10px, -50%);
   background: #2c2c2c;
   color: var(--text-color);
   padding: 0.5rem 1rem;
@@ -125,15 +126,15 @@ font-size: clamp(3rem, 8vw, 8rem);
   white-space: nowrap;
 }
 
-.about-pointer::after {
+.experience-tooltip::after {
   content: '';
   position: absolute;
-  left: 100%;
+  left: -6px;
   top: 50%;
   transform: translateY(-50%);
   border-width: 6px;
   border-style: solid;
-  border-color: transparent transparent transparent #2c2c2c;
+  border-color: transparent #2c2c2c transparent transparent;
 }
 
 .hero-image {


### PR DESCRIPTION
## Summary
- Trim the navigation to display just "ABOUT"
- Drop a friendly tooltip in the About section inviting clicks on experience

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c72e01ee0883299917d4118f85f17c