### PR TITLE
Relocate about tooltip under experience list

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@
     <div class="container">
       <div class="about-title">
         <h2 class="section-title">ABOUT.</h2>
-        <span class="experience-tooltip">Click on my experience for more details!</span>
       </div>
       <p class="about-description">I'm an Electrical &amp; Computer Engineering Co-Op student at McMaster University (GPA: 3.5/4.0) and a US &amp; Canadian citizen with experience at Microsoft, General Motors, and Tesla.</p>
+      <span class="experience-tooltip">Click on my experience for more details!</span>
       <div class="experience-filters">
         <button class="filter-btn" data-target="work">Work Experience</button>
         <button class="filter-btn active" data-target="all">All Experience</button>

--- a/style.css
+++ b/style.css
@@ -115,26 +115,12 @@ font-size: clamp(3rem, 8vw, 8rem);
 }
 
 .experience-tooltip {
-  position: absolute;
-  left: 100%;
-  top: 50%;
-  transform: translate(10px, -50%);
+  display: inline-block;
   background: #2c2c2c;
   color: var(--text-color);
   padding: 0.5rem 1rem;
   border-radius: 4px;
-  white-space: nowrap;
-}
-
-.experience-tooltip::after {
-  content: '';
-  position: absolute;
-  left: -6px;
-  top: 50%;
-  transform: translateY(-50%);
-  border-width: 6px;
-  border-style: solid;
-  border-color: transparent #2c2c2c transparent transparent;
+  margin-bottom: 1rem;
 }
 
 .hero-image {


### PR DESCRIPTION
## Summary
- Move "Click on my experience for more details!" text below the About description and above experience filters
- Update tooltip styling to fit new placement and remove arrow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7316337f0832995294fa3c10ab9d6