### PR TITLE
Populate portfolio with resume data

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,13 @@
 </head>
 <body>
   <div class="topbar">
-    <span class="intro">Hi! My name is Danilo Malovic.</span>
+    <span class="intro">Danilo Malovic · Technical Program Manager / Product Manager</span>
     <div class="social-links">
-        <a href="https://www.linkedin.com/in/danmalovic/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer">
+      <a href="https://malovic.ca" target="_blank" rel="noopener noreferrer">Website</a>
+      <a href="https://www.linkedin.com/in/danmalovic/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer">
         <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>LinkedIn</title><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.049c.476-.9 1.637-1.85 3.372-1.85 3.605 0 4.271 2.372 4.271 5.458v6.283zm-14.4-11.78c-1.144 0-2.069-.926-2.069-2.069 0-1.144.925-2.07 2.069-2.07 1.143 0 2.069.926 2.069 2.07 0 1.143-.926 2.07-2.07 2.07zM7.325 20.452H3.771V9h3.554v11.452zM22.225 0H1.771C.792 0 0 .77 0 1.723v20.549C0 23.23.792 24 1.771 24h20.451C23.2 24 24 23.23 24 22.272V1.723C24 .77 23.2 0 22.225 0z"/></svg>
       </a>
+      <a href="https://plc.malovic.ca" target="_blank" rel="noopener noreferrer">Project Site</a>
     </div>
   </div>
 
@@ -32,8 +34,18 @@
           <img src="macfe.svg" alt="MAC Formula Electric logo">
         </span>
       </a>
+      <a href="#skills">SKILLS</a>
       <a href="#contact">CONTACT</a>
     </nav>
+    <div class="hero-copy">
+      <h1 class="hero-name">Danilo Malovic</h1>
+      <p class="hero-headline">Technical Program Manager / Product Manager</p>
+      <p class="hero-location">Hamilton, ON, Canada · Dual citizen of the United States &amp; Canada</p>
+      <ul class="hero-contact-list">
+        <li><a href="mailto:danmalovic@gmail.com">danmalovic@gmail.com</a></li>
+        <li><a href="tel:+13136579446">+1-313-657-9446</a></li>
+      </ul>
+    </div>
     <div class="hero-image-wrapper">
       <img src="profile.jpg" alt="Danilo Malovic" class="hero-image">
       <span class="image-popout">This is me by Pebble Beach in California!</span>
@@ -45,55 +57,83 @@
       <div class="about-title">
         <h2 class="section-title">ABOUT.</h2>
       </div>
-      <p class="about-description">I'm an Electrical &amp; Computer Engineering Co-Op student at McMaster University (GPA: 3.5/4.0) and a US &amp; Canadian citizen with experience at Microsoft, General Motors, and Tesla.</p>
-      <span class="experience-tooltip">Click on my experience for more details!</span>
+      <p class="about-description">I'm a Technical Program Manager / Product Manager who loves shipping data-driven platforms and AI experiences. I'm currently an Electrical &amp; Computer Engineering (Co-op) student at McMaster University in Hamilton, Ontario, graduating in May 2026 after rotations at Microsoft, General Motors, and Tesla.</p>
+      <div class="about-info-cards">
+        <div class="info-card">
+          <h3>Citizenship</h3>
+          <p>United States &amp; Canada</p>
+        </div>
+        <div class="info-card">
+          <h3>Location</h3>
+          <p>Hamilton, ON, Canada</p>
+        </div>
+        <div class="info-card">
+          <h3>Education</h3>
+          <p>McMaster University — Electrical &amp; Computer Engineering (Co-op), graduating May 2026</p>
+        </div>
+      </div>
+      <span class="experience-tooltip">Explore each role to see what I shipped.</span>
       <div class="experience-filters">
-        <button class="filter-btn" data-target="work">Work Experience</button>
         <button class="filter-btn active" data-target="all">All Experience</button>
-        <button class="filter-btn" data-target="leadership">Leadership Experience</button>
+        <button class="filter-btn" data-target="work">Work Experience</button>
       </div>
       <div class="experience-content active" id="all">
         <div class="experience-grid">
           <div class="experience-card">
             <img class="experience-logo" src="microsoft.svg" alt="Microsoft logo">
-            <div>
+            <div class="experience-details">
               <h3>Microsoft</h3>
-              <p>Technical Program Manager Intern – Gaming (May–Aug 2025). Built an OKR/KPI scorecard and Azure OpenAI agent for Xbox leadership.</p>
+              <p class="experience-role">Technical Program Manager Intern – Gaming · Redmond, WA · May–Aug 2025</p>
+              <ul class="experience-highlights">
+                <li>Replaced a legacy KPI vendor with an automated SQL + Power BI platform across eight organizations (~2,000+ employees), delivering 6&times; active-user growth and +32 executive monthly engagement.</li>
+                <li>Launched an Azure OpenAI agent (150+ WAU) for natural-language KPI queries, cutting manual update work by ~85% (~25 hrs/month).</li>
+                <li>Drove discovery and PRD, prioritized with RICE, scoped the MVP, secured cross-org buy-in, and launched four weeks early.</li>
+                <li>Ran usability tests with executives and PMs, halving time to insight and raising query success from 70% to 96%.</li>
+              </ul>
             </div>
           </div>
           <div class="experience-card">
             <img class="experience-logo" src="gm.svg" alt="General Motors logo">
-            <div>
+            <div class="experience-details">
               <h3>General Motors</h3>
-              <p>Product Manager Intern – Electrical Strategy (May–Aug 2024). Defined Cadillac Optiq requirements and automated wire harness simulations with a VBA/SQL tool.</p>
+              <p class="experience-role">Product Manager Intern – Electrical Strategy and Execution · Detroit, MI · May–Aug 2024</p>
+              <ul class="experience-highlights">
+                <li>Used data from 50K+ EVs to drive a firmware update cutting battery drain by 8%, boosting CSAT, and mitigating $1.5M+ forecasted warranty exposure.</li>
+                <li>Shipped an MVP EV OTA diagnostic tool to pre-production fleets, reducing engineering triage time by 38%.</li>
+                <li>Authored a Vehicle Data API brief and validated it with 10+ enterprise partners to seed a third-party developer ecosystem.</li>
+              </ul>
             </div>
           </div>
           <div class="experience-card">
             <img class="experience-logo" src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
-            <div>
+            <div class="experience-details">
               <h3>Tesla</h3>
-              <p>Technical Program Manager Intern – New Product Introduction (Jan–May 2024). Launched new vehicle programs and coordinated compressor changes across factories, saving over $200k.</p>
+              <p class="experience-role">Technical Program Manager Co-op – New Product Introduction · San Jose, CA · Jan–May 2024</p>
+              <ul class="experience-highlights">
+                <li>Led an A/C compressor change across three factories and four models from validation through rollout, unlocking ~$800K/year savings and higher uptime.</li>
+                <li>Delivered Model S Sports Seats on time by coordinating four vendors, two factories, and eight builds for the Model S/X Lunar Silver launch.</li>
+                <li>Owned launch plans for 25+ new vehicle programs, aligning design, suppliers, manufacturing, and quality teams to hit SOP on time.</li>
+                <li>Drove KPI and part-disposition programs with RCA and supplier actions, delivering $200K+ savings and lower OPEX.</li>
+              </ul>
             </div>
           </div>
           <div class="experience-card">
             <img class="experience-logo" src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
-            <div>
+            <div class="experience-details">
               <h3>Tesla</h3>
-              <p>Electrical Engineering Intern – Equipment Testing (Sep–Dec 2023). Automated robot cleaning enclosures, cutting cycle time and saving up to 10 car bodies per shift.</p>
-            </div>
-          </div>
-          <div class="experience-card">
-            <img class="experience-logo" src="gm.svg" alt="General Motors logo">
-            <div>
-              <h3>General Motors</h3>
-              <p>Manufacturing Engineering Intern – Batteries (May–Aug 2023). Implemented autonomous guided vehicles and PLC HMI screens to boost battery production.</p>
+              <p class="experience-role">Electrical Engineering Co-op – Equipment Testing · San Jose, CA · Sep–Dec 2023</p>
+              <ul class="experience-highlights">
+                <li>Designed and programmed an automated enclosure system for cleaning robot handles, cutting cycle time by 20 minutes per shift (~19 hrs/month) and eliminating defects to avoid losses of 4–10 car bodies per shift.</li>
+                <li>Negotiated a supplier contract with an 18% unit price reduction, lead time cut from 10 to 6 weeks, and a no-charge rework clause, saving ~$30K/year across two paint lines.</li>
+              </ul>
             </div>
           </div>
           <div class="experience-card">
             <img class="experience-logo" src="mcmaster.svg" alt="McMaster University logo">
-            <div>
+            <div class="experience-details">
               <h3>McMaster University</h3>
-              <p>Electrical &amp; Computer Engineering Co-Op – Expected May 2026. GPA: 3.5/4.0.</p>
+              <p class="experience-role">Electrical &amp; Computer Engineering (Co-op) · Hamilton, ON · Graduating May 2026</p>
+              <p class="experience-summary">Co-op engineering student building technical program management, product, and automation experience.</p>
             </div>
           </div>
         </div>
@@ -102,60 +142,51 @@
         <div class="experience-grid">
           <div class="experience-card">
             <img class="experience-logo" src="microsoft.svg" alt="Microsoft logo">
-            <div>
+            <div class="experience-details">
               <h3>Microsoft</h3>
-              <p>Technical Program Manager Intern – Gaming (May–Aug 2025). Built an OKR/KPI scorecard and Azure OpenAI agent for Xbox leadership.</p>
+              <p class="experience-role">Technical Program Manager Intern – Gaming · Redmond, WA · May–Aug 2025</p>
+              <ul class="experience-highlights">
+                <li>Replaced a legacy KPI vendor with an automated SQL + Power BI platform across eight organizations (~2,000+ employees), delivering 6&times; active-user growth and +32 executive monthly engagement.</li>
+                <li>Launched an Azure OpenAI agent (150+ WAU) for natural-language KPI queries, cutting manual update work by ~85% (~25 hrs/month).</li>
+                <li>Drove discovery and PRD, prioritized with RICE, scoped the MVP, secured cross-org buy-in, and launched four weeks early.</li>
+                <li>Ran usability tests with executives and PMs, halving time to insight and raising query success from 70% to 96%.</li>
+              </ul>
             </div>
           </div>
           <div class="experience-card">
             <img class="experience-logo" src="gm.svg" alt="General Motors logo">
-            <div>
+            <div class="experience-details">
               <h3>General Motors</h3>
-              <p>Product Manager Intern – Electrical Strategy (May–Aug 2024). Defined Cadillac Optiq requirements and automated wire harness simulations with a VBA/SQL tool.</p>
+              <p class="experience-role">Product Manager Intern – Electrical Strategy and Execution · Detroit, MI · May–Aug 2024</p>
+              <ul class="experience-highlights">
+                <li>Used data from 50K+ EVs to drive a firmware update cutting battery drain by 8%, boosting CSAT, and mitigating $1.5M+ forecasted warranty exposure.</li>
+                <li>Shipped an MVP EV OTA diagnostic tool to pre-production fleets, reducing engineering triage time by 38%.</li>
+                <li>Authored a Vehicle Data API brief and validated it with 10+ enterprise partners to seed a third-party developer ecosystem.</li>
+              </ul>
             </div>
           </div>
           <div class="experience-card">
             <img class="experience-logo" src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
-            <div>
+            <div class="experience-details">
               <h3>Tesla</h3>
-              <p>Technical Program Manager Intern – New Product Introduction (Jan–May 2024). Launched new vehicle programs and coordinated compressor changes across factories, saving over $200k.</p>
+              <p class="experience-role">Technical Program Manager Co-op – New Product Introduction · San Jose, CA · Jan–May 2024</p>
+              <ul class="experience-highlights">
+                <li>Led an A/C compressor change across three factories and four models from validation through rollout, unlocking ~$800K/year savings and higher uptime.</li>
+                <li>Delivered Model S Sports Seats on time by coordinating four vendors, two factories, and eight builds for the Model S/X Lunar Silver launch.</li>
+                <li>Owned launch plans for 25+ new vehicle programs, aligning design, suppliers, manufacturing, and quality teams to hit SOP on time.</li>
+                <li>Drove KPI and part-disposition programs with RCA and supplier actions, delivering $200K+ savings and lower OPEX.</li>
+              </ul>
             </div>
           </div>
           <div class="experience-card">
             <img class="experience-logo" src="https://upload.wikimedia.org/wikipedia/commons/b/bb/Tesla_T_symbol.svg" alt="Tesla logo">
-            <div>
+            <div class="experience-details">
               <h3>Tesla</h3>
-              <p>Electrical Engineering Intern – Equipment Testing (Sep–Dec 2023). Automated robot cleaning enclosures, cutting cycle time and saving up to 10 car bodies per shift.</p>
-            </div>
-          </div>
-          <div class="experience-card">
-            <img class="experience-logo" src="gm.svg" alt="General Motors logo">
-            <div>
-              <h3>General Motors</h3>
-              <p>Manufacturing Engineering Intern – Batteries (May–Aug 2023). Implemented autonomous guided vehicles and PLC HMI screens to boost battery production.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="experience-content" id="leadership">
-        <div class="experience-grid">
-          <div class="experience-card">
-            <img class="experience-logo" src="mcmaster.svg" alt="McMaster University logo">
-            <div>
-              <h3>Senior Capstone Design Lead</h3>
-
-              <p>Led design and integration of the Custom Power Inverter project for the senior capstone.</p>
-
-            </div>
-          </div>
-          <div class="experience-card">
-            <img class="experience-logo" src="mcmaster.svg" alt="McMaster University logo">
-            <div>
-              <h3>MAC Formula Electric</h3>
-
-              <p>Senior member of the electrical subteam for the MAC Formula Electric FSAE race car project.</p>
-
-
+              <p class="experience-role">Electrical Engineering Co-op – Equipment Testing · San Jose, CA · Sep–Dec 2023</p>
+              <ul class="experience-highlights">
+                <li>Designed and programmed an automated enclosure system for cleaning robot handles, cutting cycle time by 20 minutes per shift (~19 hrs/month) and eliminating defects to avoid losses of 4–10 car bodies per shift.</li>
+                <li>Negotiated a supplier contract with an 18% unit price reduction, lead time cut from 10 to 6 weeks, and a no-charge rework clause, saving ~$30K/year across two paint lines.</li>
+              </ul>
             </div>
           </div>
         </div>
@@ -168,17 +199,66 @@
       <h2 class="section-title">Projects</h2>
       <div class="projects-grid">
         <div class="project-card">
-          <h3>Custom Power Inverter</h3>
-          <p>Led capstone design of a custom power inverter.</p>
+          <h3>AI Coding Agent for Industrial Automation</h3>
+          <p class="project-meta">Founder · Ontario, Canada · Jun 2025 &ndash; Present</p>
+          <ul class="project-highlights">
+            <li>Built an AI agent IDE that imports PLC projects for ladder-logic editing, generation, and debugging; piloting with small system integrators.</li>
+            <li>Prototyped AI-driven UI/UX patterns for PLC code editing to reimagine ladder-logic visualization and manipulation.</li>
+          </ul>
+          <a class="project-link" href="https://plc.malovic.ca" target="_blank" rel="noopener noreferrer">Visit project &rarr;</a>
         </div>
-        <div class="project-card">
-          <img class="project-logo" src="macfe.svg" alt="MAC Formula Electric logo">
-          <h3>MAC Formula Electric FSAE</h3>
-          <p>Collaborated on electric race car development for Formula SAE.</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="skills" class="full-section">
+    <div class="container">
+      <h2 class="section-title">Skills</h2>
+      <p class="skills-intro">Toolkits and frameworks I use to deliver AI-enabled products and programs.</p>
+      <div class="skills-grid">
+        <div class="skill-category">
+          <h3>Languages</h3>
+          <ul class="skill-list">
+            <li>Python</li>
+            <li>SQL</li>
+            <li>C++</li>
+            <li>C</li>
+            <li>Java</li>
+          </ul>
         </div>
-        <div class="project-card">
-          <h3>Collaborative Electronic Classroom</h3>
-          <p>Built a real-time shared "chalkboard" for synchronized multi-user drawing.</p>
+        <div class="skill-category">
+          <h3>Tools</h3>
+          <ul class="skill-list">
+            <li>Power BI</li>
+            <li>Figma</li>
+            <li>Jira</li>
+            <li>Confluence</li>
+            <li>Altium</li>
+          </ul>
+        </div>
+        <div class="skill-category">
+          <h3>Platforms</h3>
+          <ul class="skill-list">
+            <li>Azure OpenAI</li>
+            <li>Power Apps</li>
+            <li>Dataverse</li>
+          </ul>
+        </div>
+        <div class="skill-category">
+          <h3>Methods</h3>
+          <ul class="skill-list">
+            <li>A/B Testing</li>
+            <li>PRD</li>
+            <li>Roadmapping</li>
+            <li>RICE Prioritization</li>
+          </ul>
+        </div>
+        <div class="skill-category">
+          <h3>AI</h3>
+          <ul class="skill-list">
+            <li>LangChain</li>
+            <li>RAG pipelines</li>
+          </ul>
         </div>
       </div>
     </div>
@@ -187,7 +267,15 @@
   <section id="contact" class="full-section">
     <div class="container">
       <h2 class="section-title">Contact</h2>
-      <p>Feel free to reach out at <a href="mailto:danmalovic@gmail.com">danmalovic@gmail.com</a>, connect on <a href="https://www.linkedin.com/in/danmalovic/" target="_blank" rel="noopener noreferrer">LinkedIn</a>.</p>
+      <p>If you'd like to collaborate or just say hello, these are the best ways to reach me.</p>
+      <ul class="contact-list">
+        <li><strong>Email:</strong> <a href="mailto:danmalovic@gmail.com">danmalovic@gmail.com</a></li>
+        <li><strong>Phone:</strong> <a href="tel:+13136579446">+1-313-657-9446</a></li>
+        <li><strong>Location:</strong> Hamilton, ON, Canada</li>
+        <li><strong>Website:</strong> <a href="https://malovic.ca" target="_blank" rel="noopener noreferrer">malovic.ca</a></li>
+        <li><strong>LinkedIn:</strong> <a href="https://www.linkedin.com/in/danmalovic/" target="_blank" rel="noopener noreferrer">linkedin.com/in/danmalovic</a></li>
+        <li><strong>Project Site:</strong> <a href="https://plc.malovic.ca" target="_blank" rel="noopener noreferrer">plc.malovic.ca</a></li>
+      </ul>
     </div>
   </section>
   <script src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -47,25 +47,43 @@ a {
   gap: 1rem;
 }
 
+.social-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #2c2c2c;
+  color: var(--text-color);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.social-links a:hover {
+  background: var(--accent-color);
+  color: var(--text-color);
+}
+
 .social-links a svg {
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   fill: var(--text-color);
   transition: fill 0.3s ease;
 }
 
 .social-links a:hover svg {
-  fill: var(--accent-color);
+  fill: var(--text-color);
 }
-
 
 .hero-section {
   min-height: 100vh;
   display: flex;
   justify-content: flex-start;
-  align-items: center;
+  align-items: flex-start;
   gap: 5rem;
   padding: 0 5%;
+  flex-wrap: wrap;
 }
 
 .menu {
@@ -79,9 +97,7 @@ a {
 .menu a {
   color: var(--text-color);
   text-decoration: none;
-/* scales between 3rem and 8rem depending on viewport */
-font-size: clamp(3rem, 8vw, 8rem);
-
+  font-size: clamp(3rem, 8vw, 8rem);
   font-weight: 600;
   position: relative;
   display: inline-block;
@@ -109,6 +125,47 @@ font-size: clamp(3rem, 8vw, 8rem);
   width: 60px;
 }
 
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 420px;
+}
+
+.hero-name {
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  font-weight: 600;
+}
+
+.hero-headline {
+  font-size: 1.25rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.hero-location {
+  color: rgba(255, 255, 255, 0.7);
+  line-height: 1.5;
+}
+
+.hero-contact-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hero-contact-list a {
+  color: var(--accent-color);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.hero-contact-list a:hover {
+  text-decoration: underline;
+}
+
 .about-title {
   position: relative;
   display: inline-block;
@@ -130,6 +187,7 @@ font-size: clamp(3rem, 8vw, 8rem);
   border-radius: 50%;
   border: 5px solid var(--accent-color);
 }
+
 .hero-image-wrapper {
   position: relative;
   display: inline-block;
@@ -210,16 +268,44 @@ section {
   margin: 0 auto;
 }
 
-
 .section-title {
-font-size: clamp(5rem, 6vw, 7rem);
-
+  font-size: clamp(5rem, 6vw, 7rem);
   color: var(--accent-color);
   margin-bottom: 1rem;
 }
 
 .about-description {
-  margin-bottom: 2rem;
+  margin: 0 auto 2rem;
+  max-width: 900px;
+  line-height: 1.7;
+}
+
+.about-info-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.info-card {
+  background: #1f1f1f;
+  padding: 1.25rem;
+  border-radius: 8px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.info-card h3 {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-color);
+}
+
+.info-card p {
+  line-height: 1.6;
 }
 
 .experience-filters {
@@ -261,13 +347,14 @@ font-size: clamp(5rem, 6vw, 7rem);
 
 .experience-card {
   background: #1f1f1f;
-  padding: 1rem;
+  padding: 1.5rem;
   border-radius: 8px;
   display: flex;
-  align-items: center;
-  gap: 1rem;
+  align-items: flex-start;
+  gap: 1.25rem;
   position: relative;
   overflow: hidden;
+  text-align: left;
 }
 
 .experience-logo {
@@ -276,8 +363,36 @@ font-size: clamp(5rem, 6vw, 7rem);
   object-fit: contain;
   transition: transform 0.3s ease;
 }
+
 .experience-card:hover .experience-logo {
   transform: scale(1.1);
+}
+
+.experience-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.experience-role {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.75);
+  line-height: 1.5;
+}
+
+.experience-highlights {
+  margin: 0;
+  padding-left: 1.25rem;
+  list-style: disc;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  line-height: 1.6;
+}
+
+.experience-summary {
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .projects-grid {
@@ -294,6 +409,11 @@ font-size: clamp(5rem, 6vw, 7rem);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   position: relative;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+  text-align: left;
 }
 
 .project-card:hover {
@@ -311,6 +431,99 @@ font-size: clamp(5rem, 6vw, 7rem);
 
 .project-card:hover .project-logo {
   transform: scale(1.1);
+}
+
+.project-meta {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.95rem;
+}
+
+.project-highlights {
+  margin: 0;
+  padding-left: 1.25rem;
+  list-style: disc;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  line-height: 1.6;
+}
+
+.project-link {
+  color: var(--accent-color);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.project-link:hover {
+  text-decoration: underline;
+}
+
+.skills-intro {
+  max-width: 700px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.skills-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+  text-align: left;
+}
+
+.skill-category {
+  background: #1f1f1f;
+  padding: 1.5rem;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.skill-category h3 {
+  color: var(--accent-color);
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.skill-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.skill-list li {
+  line-height: 1.6;
+}
+
+.contact-list {
+  list-style: none;
+  margin: 1.5rem auto 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 480px;
+  text-align: left;
+}
+
+.contact-list strong {
+  color: rgba(255, 255, 255, 0.75);
+  font-weight: 600;
+}
+
+.contact-list a {
+  color: var(--accent-color);
+  text-decoration: none;
+}
+
+.contact-list a:hover {
+  text-decoration: underline;
 }
 
 .experience-card::after,
@@ -384,6 +597,15 @@ font-size: clamp(5rem, 6vw, 7rem);
     display: none;
   }
 
+  .hero-copy {
+    align-items: center;
+    text-align: center;
+  }
+
+  .hero-contact-list {
+    align-items: center;
+  }
+
   .hero-image {
     width: 70vw;
     height: 70vw;
@@ -393,5 +615,14 @@ font-size: clamp(5rem, 6vw, 7rem);
 
   .section-title {
     font-size: 4rem;
+  }
+
+  .about-info-cards,
+  .skills-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .experience-card {
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
## Summary
- update the hero, contact, and navigation areas with the provided basics such as headline, links, and location
- replace the experience and project content with the detailed highlights from the JSON data set
- add a dedicated skills section and refresh styling to support the richer content layout

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d0d61f16e8832986dfd4b802793480