### PR TITLE
Enlarge landing hero image

### DIFF
--- a/style.css
+++ b/style.css
@@ -184,7 +184,7 @@ a {
 .hero-visual::after {
   content: "";
   position: absolute;
-  inset: -18px;
+  inset: -24px;
   border-radius: 50%;
   background: radial-gradient(circle at 30% 30%, rgba(126, 91, 239, 0.65), transparent 70%);
   z-index: -1;
@@ -193,8 +193,8 @@ a {
 }
 
 .hero-image {
-  width: clamp(220px, 28vw, 320px);
-  height: clamp(220px, 28vw, 320px);
+  width: clamp(260px, 32vw, 380px);
+  height: clamp(260px, 32vw, 380px);
   border-radius: 50%;
   object-fit: cover;
   border: 3px solid rgba(126, 91, 239, 0.6);
@@ -583,14 +583,14 @@ section {
   }
 
   .hero-visual::after {
-    inset: -12px;
+    inset: -16px;
   }
 
   .hero-image {
-    width: 70vw;
-    height: 70vw;
-    max-width: 300px;
-    max-height: 300px;
+    width: 80vw;
+    height: 80vw;
+    max-width: 340px;
+    max-height: 340px;
   }
 
   .section-title {


### PR DESCRIPTION
## Summary
- increase the landing hero portrait dimensions and glow spacing so the image presents larger on wide screens
- raise the responsive size caps so the hero image scales larger on mobile as well

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d16dc70e6c8329a500af87bd1e7809