### PR TITLE
Add email contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         <ul class="hero-contact-list">
           <li>McMaster ECE Co-op '26</li>
           <li>Hamilton, ON, Canada</li>
-          <li><a href="mailto:danmalovic@gmail.com">danmalovic@gmail.com</a></li>
+          <li class="hero-cta"><a class="hero-contact-button" href="#contact">Let's connect</a></li>
         </ul>
       </div>
       <div class="hero-visual">
@@ -254,15 +254,41 @@
   <section id="contact" class="full-section">
     <div class="container">
       <h2 class="section-title">Contact</h2>
-      <p>If you'd like to collaborate or just say hello, these are the best ways to reach me.</p>
-      <ul class="contact-list">
-        <li><strong>Email:</strong> <a href="mailto:danmalovic@gmail.com">danmalovic@gmail.com</a></li>
-        <li><strong>Phone:</strong> <a href="tel:+13136579446">+1-313-657-9446</a></li>
-        <li><strong>Location:</strong> Hamilton, ON, Canada</li>
-        <li><strong>Website:</strong> <a href="https://malovic.ca" target="_blank" rel="noopener noreferrer">malovic.ca</a></li>
-        <li><strong>LinkedIn:</strong> <a href="https://www.linkedin.com/in/danmalovic/" target="_blank" rel="noopener noreferrer">linkedin.com/in/danmalovic</a></li>
-        <li><strong>Project Site:</strong> <a href="https://plc.malovic.ca" target="_blank" rel="noopener noreferrer">plc.malovic.ca</a></li>
-      </ul>
+      <div class="contact-content">
+        <div class="contact-intro">
+          <p>If you'd like to collaborate or just say hello, share a few details below and I'll get back to you soon.</p>
+          <ul class="contact-meta">
+            <li><strong>Location:</strong> Hamilton, ON, Canada</li>
+            <li><strong>Website:</strong> <a href="https://malovic.ca" target="_blank" rel="noopener noreferrer">malovic.ca</a></li>
+            <li><strong>LinkedIn:</strong> <a href="https://www.linkedin.com/in/danmalovic/" target="_blank" rel="noopener noreferrer">linkedin.com/in/danmalovic</a></li>
+            <li><strong>Project Site:</strong> <a href="https://plc.malovic.ca" target="_blank" rel="noopener noreferrer">plc.malovic.ca</a></li>
+          </ul>
+        </div>
+        <form id="contact-form" class="contact-form" action="https://formsubmit.co/ajax/danmalovic@gmail.com" method="POST">
+          <input type="hidden" name="_subject" value="New message from malovic.ca">
+          <input type="hidden" name="_captcha" value="false">
+          <div class="form-grid">
+            <div class="form-field">
+              <label for="contact-name">Name</label>
+              <input type="text" id="contact-name" name="name" autocomplete="name" required>
+            </div>
+            <div class="form-field">
+              <label for="contact-email">Email</label>
+              <input type="email" id="contact-email" name="email" autocomplete="email" required>
+            </div>
+            <div class="form-field">
+              <label for="contact-company">Company (optional)</label>
+              <input type="text" id="contact-company" name="company" autocomplete="organization">
+            </div>
+          </div>
+          <div class="form-field">
+            <label for="contact-message">How can I help?</label>
+            <textarea id="contact-message" name="message" rows="5" required></textarea>
+          </div>
+          <button type="submit" class="contact-submit">Send message</button>
+          <p id="contact-form-status" class="form-status" role="status" aria-live="polite"></p>
+        </form>
+      </div>
     </div>
   </section>
   </main>

--- a/script.js
+++ b/script.js
@@ -73,6 +73,60 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
+  const contactForm = document.querySelector('#contact-form');
+  const formStatus = document.querySelector('#contact-form-status');
+
+  if (contactForm) {
+    contactForm.addEventListener('submit', async event => {
+      event.preventDefault();
+
+      const submitButton = contactForm.querySelector('button[type="submit"]');
+      const originalButtonText = submitButton ? submitButton.textContent : '';
+
+      if (submitButton) {
+        submitButton.disabled = true;
+        submitButton.textContent = 'Sending…';
+      }
+
+      if (formStatus) {
+        formStatus.textContent = 'Sending your message…';
+        formStatus.classList.remove('success', 'error');
+      }
+
+      try {
+        const formData = new FormData(contactForm);
+        const response = await fetch(contactForm.action, {
+          method: 'POST',
+          body: formData,
+          headers: {
+            Accept: 'application/json',
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error('Unable to submit form');
+        }
+
+        if (formStatus) {
+          formStatus.textContent = "Thanks for reaching out! I'll get back to you soon.";
+          formStatus.classList.add('success');
+        }
+
+        contactForm.reset();
+      } catch (error) {
+        if (formStatus) {
+          formStatus.textContent = 'Sorry, something went wrong. Please try again or reach out via LinkedIn.';
+          formStatus.classList.add('error');
+        }
+      } finally {
+        if (submitButton) {
+          submitButton.disabled = false;
+          submitButton.textContent = originalButtonText;
+        }
+      }
+    });
+  }
+
   if (window.location.hash) {
     const target = document.querySelector(window.location.hash);
 

--- a/style.css
+++ b/style.css
@@ -170,6 +170,10 @@ a {
   box-shadow: 0 0 10px rgba(126, 91, 239, 0.6);
 }
 
+.hero-contact-list li.hero-cta::before {
+  display: none;
+}
+
 .hero-contact-list a {
   color: var(--text-color);
   text-decoration: none;
@@ -179,6 +183,33 @@ a {
 .hero-contact-list a:hover,
 .hero-contact-list a:focus-visible {
   color: var(--accent-color);
+}
+
+.hero-contact-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--accent-color);
+  color: var(--text-color);
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 12px 24px rgba(126, 91, 239, 0.35);
+}
+
+.hero-contact-button:hover,
+.hero-contact-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(126, 91, 239, 0.45);
+  color: var(--text-color);
+}
+
+.hero-contact-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.45);
+  outline-offset: 4px;
 }
 
 .hero-visual {
@@ -468,29 +499,151 @@ a {
   line-height: 1.6;
 }
 
-.contact-list {
+.contact-content {
+  margin: 0 auto;
+  max-width: 960px;
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: flex-start;
+  text-align: left;
+}
+
+.contact-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.contact-meta {
   list-style: none;
-  margin: 1.5rem auto 0;
+  margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  max-width: 480px;
-  text-align: left;
 }
 
-.contact-list strong {
+.contact-meta li {
+  display: flex;
+  gap: 0.5rem;
+  line-height: 1.6;
+}
+
+.contact-meta strong {
   color: rgba(255, 255, 255, 0.75);
   font-weight: 600;
 }
 
-.contact-list a {
+.contact-meta a {
   color: var(--accent-color);
   text-decoration: none;
 }
 
-.contact-list a:hover {
+.contact-meta a:hover,
+.contact-meta a:focus-visible {
   text-decoration: underline;
+}
+
+.contact-form {
+  background: #1f1f1f;
+  padding: 2.25rem;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 20px 35px rgba(0, 0, 0, 0.35);
+}
+
+.contact-form .form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-field label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.contact-form input,
+.contact-form textarea {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(12, 12, 12, 0.9);
+  color: var(--text-color);
+  padding: 0.85rem 1rem;
+  font: inherit;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.contact-form input:focus-visible,
+.contact-form textarea:focus-visible {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 3px rgba(126, 91, 239, 0.2);
+}
+
+.contact-form textarea {
+  resize: vertical;
+  min-height: 160px;
+}
+
+.contact-submit {
+  align-self: flex-start;
+  background: var(--accent-color);
+  color: var(--text-color);
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 15px 30px rgba(126, 91, 239, 0.35);
+}
+
+.contact-submit:hover,
+.contact-submit:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px rgba(126, 91, 239, 0.45);
+}
+
+.contact-submit:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.45);
+  outline-offset: 4px;
+}
+
+.contact-submit:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.form-status {
+  min-height: 1.25rem;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.form-status.success {
+  color: #6ee7b7;
+}
+
+.form-status.error {
+  color: #fca5a5;
 }
 
 .experience-card::after,


### PR DESCRIPTION
## Summary
- replace the hero email link with a call-to-action that drives visitors to the contact section
- rebuild the contact section around a responsive form that captures message details and submits to FormSubmit
- add JavaScript handling and styling for async form submission with user feedback

## Testing
- No tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1799e05ec8329adb6f3e8979fff8d