### PR TITLE
Adjust hero spacing and update location copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
         </div>
         <div class="info-card">
           <h3>Location</h3>
-          <p>Hamilton, ON, Canada</p>
+          <p>United States and Canada</p>
         </div>
         <div class="info-card">
           <h3>Education</h3>
@@ -261,7 +261,7 @@
         <div class="contact-intro">
           <p>If you'd like to collaborate or just say hello, share a few details below and I'll get back to you soon.</p>
           <ul class="contact-meta">
-            <li><strong>Location:</strong> Hamilton, ON, Canada</li>
+            <li><strong>Location:</strong> United States and Canada</li>
             <li><strong>Website:</strong> <a href="https://malovic.ca" target="_blank" rel="noopener noreferrer">malovic.ca</a></li>
             <li><strong>LinkedIn:</strong> <a href="https://www.linkedin.com/in/danmalovic/" target="_blank" rel="noopener noreferrer">linkedin.com/in/danmalovic</a></li>
             <li><strong>Project Site:</strong> <a href="https://plc.malovic.ca" target="_blank" rel="noopener noreferrer">plc.malovic.ca</a></li>

--- a/style.css
+++ b/style.css
@@ -103,13 +103,14 @@ a {
   transform: scaleX(1);
 }
 
+
 .hero-section {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: clamp(2rem, 6vw, 4rem) 1.5rem 3rem;
+  padding: clamp(1rem, 4vw, 3rem) 1.5rem 3rem;
 
   scroll-margin-top: var(--scroll-offset);
 


### PR DESCRIPTION
## Summary
- reduce top padding on the hero section to tighten whitespace at the top of the landing page
- update the About and Contact location text to "United States and Canada"

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1f76fea9c8329b50452a941467286