### PR TITLE
Refine experience summaries and surface project

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,12 +74,7 @@
             <div class="experience-details">
               <h3>Microsoft</h3>
               <p class="experience-role">Technical Program Manager Intern – Gaming · Redmond, WA · May–Aug 2025</p>
-              <ul class="experience-highlights">
-                <li>Replaced a legacy KPI vendor with an automated SQL + Power BI platform across eight organizations (~2,000+ employees), delivering 6&times; active-user growth and +32 executive monthly engagement.</li>
-                <li>Launched an Azure OpenAI agent (150+ WAU) for natural-language KPI queries, cutting manual update work by ~85% (~25 hrs/month).</li>
-                <li>Drove discovery and PRD, prioritized with RICE, scoped the MVP, secured cross-org buy-in, and launched four weeks early.</li>
-                <li>Ran usability tests with executives and PMs, halving time to insight and raising query success from 70% to 96%.</li>
-              </ul>
+              <p class="experience-summary">Replaced a legacy KPI vendor by shipping an automated SQL + Power BI platform for eight organizations and pairing it with an Azure OpenAI agent for natural-language KPI queries. Led usability testing to launch early, double engagement, and cut time to insight in half.</p>
             </div>
           </div>
           <div class="experience-card">
@@ -87,11 +82,7 @@
             <div class="experience-details">
               <h3>General Motors</h3>
               <p class="experience-role">Product Manager Intern – Electrical Strategy and Execution · Detroit, MI · May–Aug 2024</p>
-              <ul class="experience-highlights">
-                <li>Used data from 50K+ EVs to drive a firmware update cutting battery drain by 8%, boosting CSAT, and mitigating $1.5M+ forecasted warranty exposure.</li>
-                <li>Shipped an MVP EV OTA diagnostic tool to pre-production fleets, reducing engineering triage time by 38%.</li>
-                <li>Authored a Vehicle Data API brief and validated it with 10+ enterprise partners to seed a third-party developer ecosystem.</li>
-              </ul>
+              <p class="experience-summary">Analyzed telematics from 50K+ EVs to deliver a firmware update that reduced battery drain and eased warranty exposure. Shipped an MVP OTA diagnostic tool that shrank triage time by over a third and defined a Vehicle Data API vision validated with enterprise partners.</p>
             </div>
           </div>
           <div class="experience-card">
@@ -99,12 +90,7 @@
             <div class="experience-details">
               <h3>Tesla</h3>
               <p class="experience-role">Technical Program Manager Co-op – New Product Introduction · San Jose, CA · Jan–May 2024</p>
-              <ul class="experience-highlights">
-                <li>Led an A/C compressor change across three factories and four models from validation through rollout, unlocking ~$800K/year savings and higher uptime.</li>
-                <li>Delivered Model S Sports Seats on time by coordinating four vendors, two factories, and eight builds for the Model S/X Lunar Silver launch.</li>
-                <li>Owned launch plans for 25+ new vehicle programs, aligning design, suppliers, manufacturing, and quality teams to hit SOP on time.</li>
-                <li>Drove KPI and part-disposition programs with RCA and supplier actions, delivering $200K+ savings and lower OPEX.</li>
-              </ul>
+              <p class="experience-summary">Orchestrated cross-factory changes and launch plans for new Tesla vehicle programs, aligning suppliers and manufacturing teams. Delivered Model S sports seats on schedule while capturing six-figure savings and strengthening readiness across three factories.</p>
             </div>
           </div>
           <div class="experience-card">
@@ -112,10 +98,7 @@
             <div class="experience-details">
               <h3>Tesla</h3>
               <p class="experience-role">Electrical Engineering Co-op – Equipment Testing · San Jose, CA · Sep–Dec 2023</p>
-              <ul class="experience-highlights">
-                <li>Designed and programmed an automated enclosure system for cleaning robot handles, cutting cycle time by 20 minutes per shift (~19 hrs/month) and eliminating defects to avoid losses of 4–10 car bodies per shift.</li>
-                <li>Negotiated a supplier contract with an 18% unit price reduction, lead time cut from 10 to 6 weeks, and a no-charge rework clause, saving ~$30K/year across two paint lines.</li>
-              </ul>
+              <p class="experience-summary">Automated equipment cleaning to prevent paint defects and return hours to technicians each month. Renegotiated supplier agreements to lower cost, shorten lead time, and trim recurring spend across multiple paint lines.</p>
             </div>
           </div>
           <div class="experience-card">
@@ -123,7 +106,15 @@
             <div class="experience-details">
               <h3>McMaster University</h3>
               <p class="experience-role">Electrical &amp; Computer Engineering (Co-op) · Hamilton, ON · Graduating May 2026</p>
-              <p class="experience-summary">Co-op engineering student building technical program management, product, and automation experience.</p>
+              <p class="experience-summary">Co-op engineering student cultivating technical program management, product, and automation experience through industry rotations and applied projects.</p>
+            </div>
+          </div>
+          <div class="experience-card">
+            <img class="experience-logo" src="project.svg" alt="AI Coding Agent project logo">
+            <div class="experience-details">
+              <h3>AI Coding Agent for Industrial Automation</h3>
+              <p class="experience-role">Founder · Ontario, Canada · Jun 2025 – Present</p>
+              <p class="experience-summary">Built an AI agent IDE that imports PLC projects for ladder-logic editing, generation, and debugging while piloting with system integrators. Prototyping AI-driven UX for PLC development to reimagine how engineers visualize and manipulate automation code.</p>
             </div>
           </div>
         </div>
@@ -135,12 +126,7 @@
             <div class="experience-details">
               <h3>Microsoft</h3>
               <p class="experience-role">Technical Program Manager Intern – Gaming · Redmond, WA · May–Aug 2025</p>
-              <ul class="experience-highlights">
-                <li>Replaced a legacy KPI vendor with an automated SQL + Power BI platform across eight organizations (~2,000+ employees), delivering 6&times; active-user growth and +32 executive monthly engagement.</li>
-                <li>Launched an Azure OpenAI agent (150+ WAU) for natural-language KPI queries, cutting manual update work by ~85% (~25 hrs/month).</li>
-                <li>Drove discovery and PRD, prioritized with RICE, scoped the MVP, secured cross-org buy-in, and launched four weeks early.</li>
-                <li>Ran usability tests with executives and PMs, halving time to insight and raising query success from 70% to 96%.</li>
-              </ul>
+              <p class="experience-summary">Replaced a legacy KPI vendor by shipping an automated SQL + Power BI platform for eight organizations and pairing it with an Azure OpenAI agent for natural-language KPI queries. Led usability testing to launch early, double engagement, and cut time to insight in half.</p>
             </div>
           </div>
           <div class="experience-card">
@@ -148,11 +134,7 @@
             <div class="experience-details">
               <h3>General Motors</h3>
               <p class="experience-role">Product Manager Intern – Electrical Strategy and Execution · Detroit, MI · May–Aug 2024</p>
-              <ul class="experience-highlights">
-                <li>Used data from 50K+ EVs to drive a firmware update cutting battery drain by 8%, boosting CSAT, and mitigating $1.5M+ forecasted warranty exposure.</li>
-                <li>Shipped an MVP EV OTA diagnostic tool to pre-production fleets, reducing engineering triage time by 38%.</li>
-                <li>Authored a Vehicle Data API brief and validated it with 10+ enterprise partners to seed a third-party developer ecosystem.</li>
-              </ul>
+              <p class="experience-summary">Analyzed telematics from 50K+ EVs to deliver a firmware update that reduced battery drain and eased warranty exposure. Shipped an MVP OTA diagnostic tool that shrank triage time by over a third and defined a Vehicle Data API vision validated with enterprise partners.</p>
             </div>
           </div>
           <div class="experience-card">
@@ -160,12 +142,7 @@
             <div class="experience-details">
               <h3>Tesla</h3>
               <p class="experience-role">Technical Program Manager Co-op – New Product Introduction · San Jose, CA · Jan–May 2024</p>
-              <ul class="experience-highlights">
-                <li>Led an A/C compressor change across three factories and four models from validation through rollout, unlocking ~$800K/year savings and higher uptime.</li>
-                <li>Delivered Model S Sports Seats on time by coordinating four vendors, two factories, and eight builds for the Model S/X Lunar Silver launch.</li>
-                <li>Owned launch plans for 25+ new vehicle programs, aligning design, suppliers, manufacturing, and quality teams to hit SOP on time.</li>
-                <li>Drove KPI and part-disposition programs with RCA and supplier actions, delivering $200K+ savings and lower OPEX.</li>
-              </ul>
+              <p class="experience-summary">Orchestrated cross-factory changes and launch plans for new Tesla vehicle programs, aligning suppliers and manufacturing teams. Delivered Model S sports seats on schedule while capturing six-figure savings and strengthening readiness across three factories.</p>
             </div>
           </div>
           <div class="experience-card">
@@ -173,10 +150,7 @@
             <div class="experience-details">
               <h3>Tesla</h3>
               <p class="experience-role">Electrical Engineering Co-op – Equipment Testing · San Jose, CA · Sep–Dec 2023</p>
-              <ul class="experience-highlights">
-                <li>Designed and programmed an automated enclosure system for cleaning robot handles, cutting cycle time by 20 minutes per shift (~19 hrs/month) and eliminating defects to avoid losses of 4–10 car bodies per shift.</li>
-                <li>Negotiated a supplier contract with an 18% unit price reduction, lead time cut from 10 to 6 weeks, and a no-charge rework clause, saving ~$30K/year across two paint lines.</li>
-              </ul>
+              <p class="experience-summary">Automated equipment cleaning to prevent paint defects and return hours to technicians each month. Renegotiated supplier agreements to lower cost, shorten lead time, and trim recurring spend across multiple paint lines.</p>
             </div>
           </div>
         </div>

--- a/project.svg
+++ b/project.svg
@@ -1,0 +1,13 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Stylized gear surrounding spark icon</title>
+  <desc id="desc">Minimal icon representing an automation project</desc>
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7e5bef"/>
+      <stop offset="100%" stop-color="#40c9ff"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="12" fill="#1f1f1f"/>
+  <path d="M32 16l2.6 5.5 6 0.9-4.3 4.4 1 6.2-5.3-3-5.3 3 1-6.2-4.3-4.4 6-0.9L32 16z" fill="url(#grad)"/>
+  <path d="M18 36h4v10h-4zm12-4h4v14h-4zm12-6h4v20h-4z" fill="#9fa6ff" opacity="0.85"/>
+</svg>


### PR DESCRIPTION
## Summary
- replace bulleted experience highlights with concise summaries across all experience cards
- add the AI Coding Agent project to the all experience view with custom icon

## Testing
- not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68d30f9db94c8329b48970e86dbdfc44